### PR TITLE
Implement fetchBalance

### DIFF
--- a/examples/ts/hibachi-example.ts
+++ b/examples/ts/hibachi-example.ts
@@ -1,7 +1,9 @@
 import { hibachi } from '../../js/ccxt.js';
+import fs from 'fs';
 
 async function example () {
-    const exchange = new hibachi ({});
+    const keys = JSON.parse(fs.readFileSync('keys.local.json', 'utf-8'));
+    const exchange = new hibachi (keys.hibachi);
     exchange.verbose = true;
 
     const markets = await exchange.fetchMarkets();
@@ -9,5 +11,9 @@ async function example () {
 
     const currencies = await exchange.fetchCurrencies();
     console.dir (currencies, { depth: null, colors: true });
+
+    const balance = await exchange.fetchBalance();
+    console.dir (balance, { depth: null, colors: true });
+    
 }
 example ();

--- a/ts/src/abstract/hibachi.ts
+++ b/ts/src/abstract/hibachi.ts
@@ -10,6 +10,7 @@ import { Exchange as _Exchange } from '../base/Exchange.js';
 
 interface Exchange {
     publicGetMarketExchangeInfo (params?: {}): Promise<implicitReturnType>;
+    privateGetTradeAccountInfo (params?: {}): Promise<implicitReturnType>;
 }
 abstract class Exchange extends _Exchange {}
 

--- a/ts/src/hibachi.ts
+++ b/ts/src/hibachi.ts
@@ -3,7 +3,7 @@
 
 import Exchange from './abstract/hibachi.js';
 import { TICK_SIZE } from './base/functions/number.js';
-import type { Currencies, Dict, Market, Str } from './base/types.js';
+import type { Balances, Currencies, Dict, Market, Str } from './base/types.js';
 
 // ---------------------------------------------------------------------------
 
@@ -55,7 +55,7 @@ export default class hibachi extends Exchange {
                 'createTrailingPercentOrder': false,
                 'createTriggerOrder': false,
                 'fetchAccounts': false,
-                'fetchBalance': false,
+                'fetchBalance': true,
                 'fetchCanceledOrders': false,
                 'fetchClosedOrder': false,
                 'fetchClosedOrders': false,
@@ -127,6 +127,9 @@ export default class hibachi extends Exchange {
                     },
                 },
                 'private': {
+                    'get': {
+                        'trade/account/info': 1,
+                    },
                 },
             },
             'requiredCredentials': {
@@ -328,16 +331,64 @@ export default class hibachi extends Exchange {
         return result;
     }
 
+    parseBalance (response): Balances {
+        const result: Dict = {
+            'info': response,
+        };
+        // Hibachi only supports USDT on Arbitrum at this time
+        const code = this.safeCurrencyCode ('USDT');
+        const account = this.account ();
+        account['total'] = this.safeString (response, 'balance');
+        account['free'] = this.safeString (response, 'maximalWithdraw');
+        result[code] = account;
+        return this.safeBalance (result);
+    }
+
+    /**
+     * @method
+     * @name hibachi#fetchBalance
+     * @description query for balance and get the amount of funds available for trading or funds locked in orders
+     * @see https://api-doc.hibachi.xyz/#69aafedb-8274-4e21-bbaf-91dace8b8f31
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {object} a [balance structure]{@link https://docs.ccxt.com/#/?id=balance-structure}
+     */
+    async fetchBalance (params = {}): Promise<Balances> {
+        this.checkRequiredCredentials ();
+        const request: Dict = {
+            'accountId': this.accountId,
+        };
+        const response = await this.privateGetTradeAccountInfo (this.extend (request, params));
+        //
+        // {
+        //     assets: [ { quantity: '3.000000', symbol: 'USDT' } ],
+        //     balance: '3.000000',
+        //     maximalWithdraw: '3.000000',
+        //     numFreeTransfersRemaining: '100',
+        //     positions: [],
+        //     totalOrderNotional: '0.000000',
+        //     totalPositionNotional: '0.000000',
+        //     totalUnrealizedFundingPnl: '0.000000',
+        //     totalUnrealizedPnl: '0.000000',
+        //     totalUnrealizedTradingPnl: '0.000000',
+        //     tradeMakerFeeRate: '0.00000000',
+        //     tradeTakerFeeRate: '0.00020000'
+        // }
+        //
+        return this.parseBalance (response);
+    }
+
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
         const request = this.omit (params, this.extractParams (path));
         const endpoint = '/' + this.implodeParams (path, params);
         let url = this.urls['api'][api] + endpoint;
         const query = this.urlencode (request);
-        if (api === 'private') {
-            // TODO: add auth header with API key here
-            headers = this.extend (headers, {});
-        } else if (query.length !== 0) {
+        if (query.length !== 0) {
             url += '?' + query;
+        }
+        if (api === 'private') {
+            headers = {
+                'Authorization': this.apiKey,
+            };
         }
         return { 'url': url, 'method': method, 'body': body, 'headers': headers };
     }


### PR DESCRIPTION
Added fetchBalance, it will use the account-info endpoint to get total and available USDT balances.
We will need to setup account locally to run the tests, see [wiki](https://app.gitbook.com/o/9p0LQCi8qKNst1N5BLDl/s/bwdCxysaZTAI6Ih4fwzY/ccxt-integration/dev-setup#testing-private-api)

**Test**
1. Build with `npm run build` and can pass.
2. Unit test with private endpoints can pass for JS/TS/Python/Python-async: <img width="739" alt="Screenshot 2025-07-09 at 5 18 11 PM" src="https://github.com/user-attachments/assets/fef47a0f-5f19-4747-aec8-33be1b7b7cef" />
3. Run example, here is the output for balances and the numbers on UI: <img width="523" alt="Screenshot 2025-07-09 at 4 07 22 PM" src="https://github.com/user-attachments/assets/a93fc0c8-ebd7-4844-a8a4-2219f0382c7f" /> <img width="311" alt="Screenshot 2025-07-09 at 4 06 58 PM" src="https://github.com/user-attachments/assets/718c3b74-d6f3-4481-920f-8a85648cba91" />

