### PR TITLE
[ENG-5178] Public - Market Data - fetchTrades

### DIFF
--- a/examples/ts/hibachi-example.ts
+++ b/examples/ts/hibachi-example.ts
@@ -9,5 +9,8 @@ async function example () {
 
     const currencies = await exchange.fetchCurrencies();
     console.dir (currencies, { depth: null, colors: true });
+
+    const trades = await exchange.fetchTrades("BTC/USDT:USDT");
+    console.log('fetchTrades', trades.length, trades[0]);
 }
 example ();

--- a/ts/src/abstract/hibachi.ts
+++ b/ts/src/abstract/hibachi.ts
@@ -10,6 +10,7 @@ import { Exchange as _Exchange } from '../base/Exchange.js';
 
 interface Exchange {
     publicGetMarketExchangeInfo (params?: {}): Promise<implicitReturnType>;
+    publicGetMarketDataTrades (params?: {}): Promise<implicitReturnType>;
 }
 abstract class Exchange extends _Exchange {}
 

--- a/ts/src/hibachi.ts
+++ b/ts/src/hibachi.ts
@@ -3,7 +3,7 @@
 
 import Exchange from './abstract/hibachi.js';
 import { TICK_SIZE } from './base/functions/number.js';
-import type { Currencies, Dict, Market, Str } from './base/types.js';
+import type { Currencies, Dict, Market, Str, Trade, Int } from './base/types.js';
 
 // ---------------------------------------------------------------------------
 
@@ -95,7 +95,7 @@ export default class hibachi extends Exchange {
                 'fetchTicker': false,
                 'fetchTickers': false,
                 'fetchTime': false,
-                'fetchTrades': false,
+                'fetchTrades': true,
                 'fetchTradingFee': false,
                 'fetchTradingFees': false,
                 'fetchTransactions': 'emulated',
@@ -124,6 +124,7 @@ export default class hibachi extends Exchange {
                 'public': {
                     'get': {
                         'market/exchange-info': 1,
+                        'market/data/trades': 1,
                     },
                 },
                 'private': {
@@ -326,6 +327,72 @@ export default class hibachi extends Exchange {
             'info': {},
         });
         return result;
+    }
+
+    parseTrade (trade: Dict, market: Market = undefined): Trade {
+        // public fetchTrades:
+        //      {
+        //          "price": "3512.431902",
+        //          "quantity": "1.414780098",
+        //          "takerSide": "Buy",
+        //          "timestamp": 1712692147
+        //      }
+        const timestamp = this.safeTimestamp (trade, 'timestamp'); // in seconds
+        const price = this.safeString (trade, 'price');
+        const amount = this.safeString (trade, 'quantity');
+        let side = this.safeString (trade, 'takerSide');
+        if (side !== undefined) {
+            side = side.toLowerCase ();
+        }
+        return this.safeTrade ({
+            'id': undefined,
+            'order': undefined,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'symbol': this.safeSymbol (undefined, market),
+            'type': undefined,
+            'side': side,
+            'price': price,
+            'amount': amount,
+            'cost': undefined,
+            'takerOrMaker': 'taker',
+            'fee': undefined,
+            'info': trade,
+        }, market);
+    }
+
+    /**
+     * @method
+     * @name hibachi#fetchTrades
+     * @description get the list of most recent trades for a particular symbol
+     * @see https://api-doc.hibachi.xyz/#86a53bc1-d3bb-4b93-8a11-7034d4698caa
+     * @param {string} symbol unified market symbol
+     * @param {int} [since] timestamp in ms of the earliest trade to fetch
+     * @param {int} [limit] the maximum amount of trades to fetch (maximum value is 100)
+     * @param {object} [params] extra parameters specific to the hibachi api endpoint
+     * @returns {object[]} a list of recent [trade structures]
+     */
+    async fetchTrades (symbol: string, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Trade[]> {
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const request = {
+            'symbol': market['id'],
+        };
+        const response = await this.publicGetMarketDataTrades (this.extend (request, params));
+        //
+        // {
+        //     "trades": [
+        //         {
+        //             "price": "111091.38352",
+        //             "quantity": "0.0090090093",
+        //             "takerSide": "Buy",
+        //             "timestamp": 1752095479
+        //         },
+        //     ]
+        // }
+        //
+        const trades = this.safeList (response, 'trades', []);
+        return this.parseTrades (trades, market);
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {


### PR DESCRIPTION
# Changes
- Added fetchTrades (public)

# Tests
- Build with npm run build and can pass.
- Unit test can pass:
```
projectFolderyangqu@Mac ccxt % node run-tests --ts --js --python --python-async --info hibachi
Testing { exchanges: ["hibachi"], method: undefined, symbol: "all", debugKeys: { '--warnings': false, '--info': true }, langKeys: { '--ts': true, '--js': true, '--php': false, '--python': true, '--python-async': true, '--csharp': false, '--php-async': false, '--go': false }, exchangeSpecificFlags: { '--ws': false, '--sandbox': false, '--useProxy': false, '--verbose': false, '--private': false, '--privateOnly': false, '--request': false, '--response': false }, maxConcurrency: 5 } (run-tests.js:424)
[100%] Tested hibachi  OK (testExchange @ run-tests.js:327)

        |-------------- INFO --------------|



        [INFO] TESTING  js {
        [INFO] TESTING            hibachi loadMarkets ([])
        [INFO] TESTING DONE       hibachi loadMarkets
        [INFO:MAIN] Exchange loaded 18 symbols
        [INFO:MAIN] Selected SWAP SYMBOL: BTC/USDT:USDT
        [INFO] ### SWAP TESTS ###
        [INFO] TESTING            hibachi features ([])
        [INFO] TESTING            hibachi fetchCurrencies ([])
        [INFO] UNSUPPORTED_TEST   hibachi fetchTicker
        [INFO] UNSUPPORTED_TEST   hibachi fetchTickers
        [INFO] UNSUPPORTED_TEST   hibachi fetchLastPrices
        [INFO] UNSUPPORTED_TEST   hibachi fetchOHLCV
        [INFO] TESTING            hibachi fetchTrades (["BTC/USDT:USDT"])
        [INFO] UNSUPPORTED_TEST   hibachi fetchOrderBook
        [INFO] UNSUPPORTED_TEST   hibachi fetchOrderBooks
        [INFO] UNSUPPORTED_TEST   hibachi fetchBidsAsks
        [INFO] UNSUPPORTED_TEST   hibachi fetchStatus
        [INFO] UNSUPPORTED_TEST   hibachi fetchTime
        [INFO] UNSUPPORTED_TEST   hibachi fetchFundingRates
        [INFO] UNSUPPORTED_TEST   hibachi fetchFundingRate
        [INFO] UNSUPPORTED_TEST   hibachi fetchFundingRateHistory
        [INFO] UNSUPPORTED_TEST   hibachi fetchIndexOHLCV
        [INFO] UNSUPPORTED_TEST   hibachi fetchMarkOHLCV
        [INFO] UNSUPPORTED_TEST   hibachi fetchPremiumIndexOHLCV
        [INFO] TESTING DONE       hibachi features
        [INFO] TESTING DONE       hibachi fetchCurrencies
        [INFO] TESTING DONE       hibachi fetchTrades
        [INFO] END PUBLIC_TESTS hibachi



        [INFO] TESTING  py {'exchange': 'hibachi', 'symbol': None, 'method': None, 'isWs': False, 'useProxy': False} 
        [INFO] TESTING            hibachi loadMarkets ([])
        [INFO] TESTING DONE       hibachi loadMarkets
        [INFO:MAIN] Exchange loaded 18 symbols
        [INFO:MAIN] Selected SWAP SYMBOL: BTC/USDT:USDT
        [INFO] ### SWAP TESTS ###
        [INFO] TESTING            hibachi features ([])
        [INFO] TESTING DONE       hibachi features
        [INFO] TESTING            hibachi fetchCurrencies ([])
        [INFO] TESTING DONE       hibachi fetchCurrencies
        [INFO] UNSUPPORTED_TEST   hibachi fetchTicker
        [INFO] UNSUPPORTED_TEST   hibachi fetchTickers
        [INFO] UNSUPPORTED_TEST   hibachi fetchLastPrices
        [INFO] UNSUPPORTED_TEST   hibachi fetchOHLCV
        [INFO] TESTING            hibachi fetchTrades (["BTC/USDT:USDT"])
        [INFO] UNSUPPORTED_TEST   hibachi fetchOrderBook
        [INFO] UNSUPPORTED_TEST   hibachi fetchOrderBooks
        [INFO] UNSUPPORTED_TEST   hibachi fetchBidsAsks
        [INFO] UNSUPPORTED_TEST   hibachi fetchStatus
        [INFO] UNSUPPORTED_TEST   hibachi fetchTime
        [INFO] UNSUPPORTED_TEST   hibachi fetchFundingRates
        [INFO] UNSUPPORTED_TEST   hibachi fetchFundingRate
        [INFO] UNSUPPORTED_TEST   hibachi fetchFundingRateHistory
        [INFO] UNSUPPORTED_TEST   hibachi fetchIndexOHLCV
        [INFO] UNSUPPORTED_TEST   hibachi fetchMarkOHLCV
        [INFO] UNSUPPORTED_TEST   hibachi fetchPremiumIndexOHLCV
        [INFO] TESTING DONE       hibachi fetchTrades
        [INFO] END PUBLIC_TESTS hibachi



        [INFO] TESTING  ts {
        [INFO] TESTING            hibachi loadMarkets ([])
        [INFO] TESTING DONE       hibachi loadMarkets
        [INFO:MAIN] Exchange loaded 18 symbols
        [INFO:MAIN] Selected SWAP SYMBOL: BTC/USDT:USDT
        [INFO] ### SWAP TESTS ###
        [INFO] TESTING            hibachi features ([])
        [INFO] TESTING            hibachi fetchCurrencies ([])
        [INFO] UNSUPPORTED_TEST   hibachi fetchTicker
        [INFO] UNSUPPORTED_TEST   hibachi fetchTickers
        [INFO] UNSUPPORTED_TEST   hibachi fetchLastPrices
        [INFO] UNSUPPORTED_TEST   hibachi fetchOHLCV
        [INFO] TESTING            hibachi fetchTrades (["BTC/USDT:USDT"])
        [INFO] UNSUPPORTED_TEST   hibachi fetchOrderBook
        [INFO] UNSUPPORTED_TEST   hibachi fetchOrderBooks
        [INFO] UNSUPPORTED_TEST   hibachi fetchBidsAsks
        [INFO] UNSUPPORTED_TEST   hibachi fetchStatus
        [INFO] UNSUPPORTED_TEST   hibachi fetchTime
        [INFO] UNSUPPORTED_TEST   hibachi fetchFundingRates
        [INFO] UNSUPPORTED_TEST   hibachi fetchFundingRate
        [INFO] UNSUPPORTED_TEST   hibachi fetchFundingRateHistory
        [INFO] UNSUPPORTED_TEST   hibachi fetchIndexOHLCV
        [INFO] UNSUPPORTED_TEST   hibachi fetchMarkOHLCV
        [INFO] UNSUPPORTED_TEST   hibachi fetchPremiumIndexOHLCV
        [INFO] TESTING DONE       hibachi features
        [INFO] TESTING DONE       hibachi fetchCurrencies
        [INFO] TESTING DONE       hibachi fetchTrades
        [INFO] END PUBLIC_TESTS hibachi



        [INFO] TESTING  py {'exchange': 'hibachi', 'symbol': None, 'method': None, 'isWs': False, 'useProxy': False} 
        [INFO] TESTING            hibachi loadMarkets ([])
        [INFO] TESTING DONE       hibachi loadMarkets
        [INFO:MAIN] Exchange loaded 18 symbols
        [INFO:MAIN] Selected SWAP SYMBOL: BTC/USDT:USDT
        [INFO] ### SWAP TESTS ###
        [INFO] TESTING            hibachi features ([])
        [INFO] TESTING DONE       hibachi features
        [INFO] TESTING            hibachi fetchCurrencies ([])
        [INFO] TESTING DONE       hibachi fetchCurrencies
        [INFO] UNSUPPORTED_TEST   hibachi fetchTicker
        [INFO] UNSUPPORTED_TEST   hibachi fetchTickers
        [INFO] UNSUPPORTED_TEST   hibachi fetchLastPrices
        [INFO] UNSUPPORTED_TEST   hibachi fetchOHLCV
        [INFO] TESTING            hibachi fetchTrades (["BTC/USDT:USDT"])
        [INFO] TESTING DONE       hibachi fetchTrades
        [INFO] UNSUPPORTED_TEST   hibachi fetchOrderBook
        [INFO] UNSUPPORTED_TEST   hibachi fetchOrderBooks
        [INFO] UNSUPPORTED_TEST   hibachi fetchBidsAsks
        [INFO] UNSUPPORTED_TEST   hibachi fetchStatus
        [INFO] UNSUPPORTED_TEST   hibachi fetchTime
        [INFO] UNSUPPORTED_TEST   hibachi fetchFundingRates
        [INFO] UNSUPPORTED_TEST   hibachi fetchFundingRate
        [INFO] UNSUPPORTED_TEST   hibachi fetchFundingRateHistory
        [INFO] UNSUPPORTED_TEST   hibachi fetchIndexOHLCV
        [INFO] UNSUPPORTED_TEST   hibachi fetchMarkOHLCV
        [INFO] UNSUPPORTED_TEST   hibachi fetchPremiumIndexOHLCV
        [INFO] END PUBLIC_TESTS hibachi
        |--------------------------------------------| (testExchange @ run-tests.js:335)

All done, 1 succeeded (run-tests.js:446)
```
- Run example, here is the output for trades:
```
etchTrades 100 {
  id: undefined,
  order: undefined,
  timestamp: 1752105994000,
  datetime: '2025-07-10T00:06:34.000Z',
  symbol: 'BTC/USDT:USDT',
  type: undefined,
  side: 'buy',
  price: 111313.8,
  amount: 0.0002,
  cost: 22.26276,
  takerOrMaker: 'taker',
  fee: { cost: undefined, currency: undefined },
  info: {
    price: '111313.80000',
    quantity: '0.0002000000',
    takerSide: 'Buy',
    timestamp: '1752105994'
  },
  fees: []
}
```