### PR TITLE
Implement cancelOrder

### DIFF
--- a/examples/ts/hibachi-example.ts
+++ b/examples/ts/hibachi-example.ts
@@ -14,6 +14,9 @@ async function example () {
 
     const balance = await exchange.fetchBalance();
     console.dir (balance, { depth: null, colors: true });
-    
+
+    // In order to run this, please change it to a valid order ID
+    // const cancelOrder = await exchange.cancelOrder('111111111111111111');
+    // console.dir (cancelOrder, { depth: null, colors: true });
 }
 example ();

--- a/ts/src/abstract/hibachi.ts
+++ b/ts/src/abstract/hibachi.ts
@@ -11,6 +11,7 @@ import { Exchange as _Exchange } from '../base/Exchange.js';
 interface Exchange {
     publicGetMarketExchangeInfo (params?: {}): Promise<implicitReturnType>;
     privateGetTradeAccountInfo (params?: {}): Promise<implicitReturnType>;
+    privateDeleteTradeOrder (params?: {}): Promise<implicitReturnType>;
 }
 abstract class Exchange extends _Exchange {}
 


### PR DESCRIPTION
In this PR we add support for:
1. Signature generation. (For trustless account only, exchange managed account will be added later if we have time)
2. cancelOrder

**Test**
1. `npm run build` can pass
2. Unit tests can pass: `node run-tests --ts --js --python --python-async --info hibachi --private`, note that they don't provide a test for `cancelOrder`. <img width="742" height="693" alt="Screenshot 2025-07-10 at 11 45 30 AM" src="https://github.com/user-attachments/assets/cc67ee6b-bfe3-4dc8-9ee1-186f7188abe2" />
3. Run examples: need to create an order manually on UI and put the order ID in the example. We can see the order got cancelled on UI. <img width="345" height="462" alt="Screenshot 2025-07-10 at 11 44 24 AM" src="https://github.com/user-attachments/assets/1bbbead2-f899-4706-9001-3e825eadbdc4" />


