### PR TITLE
Implement editOrder

### DIFF
--- a/examples/ts/hibachi-example.ts
+++ b/examples/ts/hibachi-example.ts
@@ -21,13 +21,14 @@ async function example () {
     const ticker = await exchange.fetchTicker('BTC/USDT:USDT');
     console.log ('fetchTicket', ticker);
 
-    // createOrder and cancelOrder
+    // createOrder, editOrder and cancelOrder
     const order1 = await exchange.createOrder('BTC/USDT:USDT', 'market', 'buy', 0.00002);
     const order2 = await exchange.createOrder('BTC/USDT:USDT', 'market', 'sell', 0.00002);
     console.log('create market order', order1.id, order2.id);
     const order3 = await exchange.createOrder('ETH/USDT:USDT', 'limit', 'buy', 1.234, 1.234);
-    const order4 = await exchange.cancelOrder(order3.id);
-    console.log('create and cancel limit order', order3.id, order4.id);
+    const order4 = await exchange.editOrder(order3.id, 'ETH/USDT:USDT', 'limit', 'buy', 0.987, 1.123);
+    const order5 = await exchange.cancelOrder(order3.id);
+    console.log('create, edit and cancel limit order', order3.id, order4.id, order5.id);
     
 }
 example ();

--- a/ts/src/abstract/hibachi.ts
+++ b/ts/src/abstract/hibachi.ts
@@ -14,6 +14,7 @@ interface Exchange {
     publicGetMarketDataPrices (params?: {}): Promise<implicitReturnType>;
     publicGetMarketDataStats (params?: {}): Promise<implicitReturnType>;
     privateGetTradeAccountInfo (params?: {}): Promise<implicitReturnType>;
+    privatePutTradeOrder (params?: {}): Promise<implicitReturnType>;
     privateDeleteTradeOrder (params?: {}): Promise<implicitReturnType>;
     privatePostTradeOrder (params?: {}): Promise<implicitReturnType>;
 }


### PR DESCRIPTION
We reuse the same signature logic to implement editOrder.

Modified the example to do creation, edit and cancel one after another.

**Test**
Build and unit tests can pass. (There is no built-in test for editOrder)
Run example (only creation and edit), we can see the order got edited correctly:
<img width="1058" height="152" alt="Screenshot 2025-07-11 at 3 15 49 PM" src="https://github.com/user-attachments/assets/d350e35d-e739-4e13-ab25-eab7a831e161" />

