### PR TITLE
Implement withdraw

### DIFF
--- a/examples/ts/hibachi-example.ts
+++ b/examples/ts/hibachi-example.ts
@@ -1,6 +1,21 @@
 import { hibachi } from '../../js/ccxt.js';
 import fs from 'fs';
 
+/*
+    In order to run the examples, you need to setup keys.local.json file like this:
+    ```
+    {
+        "hibachi": {
+            "accountId": 111,
+            "apiKey": "1111111111111111111111111111111111111111111=",
+            "privateKey": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "withdrawAddress": "0x1111111111111111111111111111111111111111"
+        }
+    }
+    ```
+    You can get the accountId, apiKey and privateKey from Hibachi App by creating an API key
+    The withdrawAddress can be any ethereum wallet address, that is used to receive funds for withdraw tests
+*/
 async function example () {
     const keys = JSON.parse(fs.readFileSync('keys.local.json', 'utf-8'));
     const exchange = new hibachi (keys.hibachi);
@@ -32,5 +47,8 @@ async function example () {
     
     const orderbook = await exchange.fetchOrderBook('BTC/USDT:USDT');
     console.log ('fetchOrderBook', orderbook);
+
+    const withdrawResponse = await exchange.withdraw('USDT', 0.02, keys.hibachi.withdrawAddress);
+    console.log(withdrawResponse);
 }
 example ();

--- a/ts/src/abstract/hibachi.ts
+++ b/ts/src/abstract/hibachi.ts
@@ -13,10 +13,12 @@ interface Exchange {
     publicGetMarketDataTrades (params?: {}): Promise<implicitReturnType>;
     publicGetMarketDataPrices (params?: {}): Promise<implicitReturnType>;
     publicGetMarketDataStats (params?: {}): Promise<implicitReturnType>;
+    publicGetMarketDataOrderbook (params?: {}): Promise<implicitReturnType>;
     privateGetTradeAccountInfo (params?: {}): Promise<implicitReturnType>;
     privatePutTradeOrder (params?: {}): Promise<implicitReturnType>;
     privateDeleteTradeOrder (params?: {}): Promise<implicitReturnType>;
     privatePostTradeOrder (params?: {}): Promise<implicitReturnType>;
+    privatePostCapitalWithdraw (params?: {}): Promise<implicitReturnType>;
 }
 abstract class Exchange extends _Exchange {}
 


### PR DESCRIPTION
Implemented withdraw endpoint with signature payload generation logic.
We use the Arbitrum USDT standard withdraw (since that is the currency we have) with automatic relay.

Note: we will need to put the withdraw address in `keys.local.json` to run the examples, added a comment about it.

**Test**
Build and unit tests can pass. (There is no built-in unit test for withdrawal)
Run the example, here is the output:
<img width="472" height="365" alt="Screenshot 2025-07-14 at 3 30 11 PM" src="https://github.com/user-attachments/assets/62f62e14-9b41-4515-bd85-e2926feb52fa" />
We can see it on the UI:
<img width="367" height="112" alt="Screenshot 2025-07-14 at 3 07 17 PM" src="https://github.com/user-attachments/assets/d5617be8-b3a7-4682-a25b-b6db5bffce4d" />
