### PR TITLE
Implement `fetchDepositAddress`

### DIFF
--- a/examples/ts/hibachi-example.ts
+++ b/examples/ts/hibachi-example.ts
@@ -53,5 +53,8 @@ async function example () {
     
     const tradingFees = await exchange.fetchTradingFees ();
     console.log ('fetchTradingFees', tradingFees);
+
+    const depositAddress = await exchange.fetchDepositAddress ('USDT');
+    console.log ('fetchDepositAddress', depositAddress);
 }
 example ();

--- a/ts/src/abstract/hibachi.ts
+++ b/ts/src/abstract/hibachi.ts
@@ -15,6 +15,7 @@ interface Exchange {
     publicGetMarketDataStats (params?: {}): Promise<implicitReturnType>;
     publicGetMarketDataOrderbook (params?: {}): Promise<implicitReturnType>;
     privateGetTradeAccountInfo (params?: {}): Promise<implicitReturnType>;
+    privateGetCapitalDepositInfo (params?: {}): Promise<implicitReturnType>;
     privatePutTradeOrder (params?: {}): Promise<implicitReturnType>;
     privateDeleteTradeOrder (params?: {}): Promise<implicitReturnType>;
     privatePostTradeOrder (params?: {}): Promise<implicitReturnType>;

--- a/ts/src/hibachi.ts
+++ b/ts/src/hibachi.ts
@@ -1050,7 +1050,7 @@ export default class hibachi extends Exchange {
     /**
      * @method
      * @name hibachi#fetchDepositAddress
-     * @description fetch deposit address for given currency and chain. currently, we have a single EVM address across multiple EVM chains
+     * @description fetch deposit address for given currency and chain. currently, we have a single EVM address across multiple EVM chains. Note: This method is currently only supported for trustless accounts
      * @param {string} code unified currency code
      * @param {object} [params] extra parameters for API
      * @returns {object} an [address structure]{@link https://docs.ccxt.com/#/?id=address-structure}

--- a/ts/src/hibachi.ts
+++ b/ts/src/hibachi.ts
@@ -1056,6 +1056,7 @@ export default class hibachi extends Exchange {
      * @returns {object} an [address structure]{@link https://docs.ccxt.com/#/?id=address-structure}
      */
     async fetchDepositAddress (code: string, params = {}): Promise<DepositAddress> {
+        this.checkRequiredCredentials ();
         const publicKey = this.derivePublicKeyFromPrivate ();
         const request = {
             'publicKey': '0x' + this.binaryToBase16 (publicKey),

--- a/ts/src/hibachi.ts
+++ b/ts/src/hibachi.ts
@@ -1067,8 +1067,8 @@ export default class hibachi extends Exchange {
         // }
         return {
             'info': response,
-            'currency': undefined,
-            'network': undefined,
+            'currency': 'USDT',
+            'network': 'ARBITRUM',
             'address': this.safeString (response, 'depositAddressEvm'),
             'tag': undefined,
         };


### PR DESCRIPTION
There is one question regarding the clarity of information: from `fetchCurrencies` we only support USDT. This deposit address, on the other hand, works for USDT + USDC on Arbitrum/Base. Do we want to expose that information, or is just giving an address enough?

This PR:
1. Fetches the deposit address (hardcoded for USDT + Arbitrum). Crosschain support can be added in a future PR
2. Only supports trustless accounts, since the publicKey can only be fetched from the `user/subaccount` endpoint which requires user session for authentication.

# Testing Output
Build passes, and there isn't a unit test for this endpoint
```
fetchDepositAddress {
  info: { depositAddressEvm: '0x6102a7a98a531ae5535f4b0abba789545ea63fcc' },
  currency: 'USDT',
  network: 'ARBITRUM',
  address: '0x6102a7a98a531ae5535f4b0abba789545ea63fcc',
  tag: undefined
}
```