### PR TITLE
Implement `fetchOpenOrders`

### DIFF
--- a/examples/ts/hibachi-example.ts
+++ b/examples/ts/hibachi-example.ts
@@ -57,7 +57,7 @@ async function example () {
 
     const tradingFees = await exchange.fetchTradingFees ();
     console.log ('fetchTradingFees', tradingFees);
-    
+
     const depositAddress = await exchange.fetchDepositAddress ('USDT');
     console.log ('fetchDepositAddress', depositAddress);
 

--- a/examples/ts/hibachi-example.ts
+++ b/examples/ts/hibachi-example.ts
@@ -57,5 +57,14 @@ async function example () {
 
     const tradingFees = await exchange.fetchTradingFees ();
     console.log ('fetchTradingFees', tradingFees);
+
+    const openOrders = await exchange.fetchOpenOrders ();
+    console.log ('fetchOpenOrders', openOrders);
+    const openOrdersWithLimit = await exchange.fetchOpenOrders (undefined, undefined, 1);
+    console.log ('fetchOpenOrdersWithLimit', openOrdersWithLimit);
+    const openOrdersBTC = await exchange.fetchOpenOrders ('BTC/USDT:USDT');
+    console.log ('fetchOpenOrdersBTC', openOrdersBTC);
+    const openOrdersSince = await exchange.fetchOpenOrders (undefined, 1752552000000); // 7/15/2025 00:00 UTC
+    console.log ('fetchOpenOrdersSince', openOrdersSince);
 }
 example ();

--- a/ts/src/abstract/hibachi.ts
+++ b/ts/src/abstract/hibachi.ts
@@ -16,6 +16,7 @@ interface Exchange {
     publicGetMarketDataOrderbook (params?: {}): Promise<implicitReturnType>;
     privateGetTradeAccountInfo (params?: {}): Promise<implicitReturnType>;
     privateGetTradeAccountTrades (params?: {}): Promise<implicitReturnType>;
+    privateGetTradeOrders (params?: {}): Promise<implicitReturnType>;
     privatePutTradeOrder (params?: {}): Promise<implicitReturnType>;
     privateDeleteTradeOrder (params?: {}): Promise<implicitReturnType>;
     privatePostTradeOrder (params?: {}): Promise<implicitReturnType>;

--- a/ts/src/hibachi.ts
+++ b/ts/src/hibachi.ts
@@ -1066,7 +1066,7 @@ export default class hibachi extends Exchange {
      * @name hibachi#fetchOpenOrders
      * @description fetches all current open orders
      * @see https://api-doc.hibachi.xyz/#3243f8a0-086c-44c5-ab8a-71bbb7bab403
-     * @param {string} symbol unified market symbol to filter by
+     * @param {string} [symbol] unified market symbol to filter by
      * @param {int} [since] milisecond timestamp of the earliest order
      * @param {int} [limit] the maximum number of open orders to return
      * @param {object} [params] extra parameters

--- a/ts/src/hibachi.ts
+++ b/ts/src/hibachi.ts
@@ -681,15 +681,16 @@ export default class hibachi extends Exchange {
         const orderFlags = this.safeValue (order, 'orderFlags');
         let postOnly = false;
         let reduceOnly = false;
-        if (orderFlags === 'PostOnly') {
+        if (orderFlags === 'POST_ONLY') {
             timeInForce = 'PO';
             postOnly = true;
-        } else if (orderFlags === 'Ioc') {
+        } else if (orderFlags === 'IOC') {
             timeInForce = 'IOC';
-        } else if (orderFlags === 'ReduceOnly') {
+        } else if (orderFlags === 'REDUCE_ONLY') {
             reduceOnly = true;
         }
         return this.safeOrder ({
+            'info': order,
             'id': this.safeString (order, 'orderId'),
             'clientOrderId': undefined,
             'datetime': undefined,
@@ -711,7 +712,7 @@ export default class hibachi extends Exchange {
             'fee': undefined,
             'reduceOnly': reduceOnly,
             'postOnly': postOnly,
-            'info': order,
+            'triggerPrice': this.safeNumber (order, 'triggerPrice'),
         }, market);
     }
 
@@ -1257,7 +1258,7 @@ export default class hibachi extends Exchange {
         return this.parseOrders (response, market, since, limit, params);
     }
 
-    /*
+    /**
      * @name hibachi#fetchOHLCV
      * @see  https://api-doc.hibachi.xyz/#4f0eacec-c61e-4d51-afb3-23c51c2c6bac
      * @description fetches historical candlestick data containing the close, high, low, open prices, interval and the volumeNotional

--- a/ts/src/hibachi.ts
+++ b/ts/src/hibachi.ts
@@ -3,7 +3,7 @@
 
 import Exchange from './abstract/hibachi.js';
 import { TICK_SIZE } from './base/functions/number.js';
-import type { Balances, Currencies, Dict, Market, Str, Ticker, Trade, Int, Num, OrderSide, OrderType, OrderBook, TradingFees, Transaction } from './base/types.js';
+import type { Balances, Currencies, Dict, Market, Str, Ticker, Trade, Int, Num, OrderSide, OrderType, OrderBook, TradingFees, Transaction, Order } from './base/types.js';
 import { ecdsa, hmac } from './base/functions/crypto.js';
 import { sha256 } from './static_dependencies/noble-hashes/sha256.js';
 import { secp256k1 } from './static_dependencies/noble-curves/secp256k1.js';
@@ -87,7 +87,7 @@ export default class hibachi extends Exchange {
                 'fetchOHLCV': false,
                 'fetchOpenInterestHistory': false,
                 'fetchOpenOrder': false,
-                'fetchOpenOrders': false,
+                'fetchOpenOrders': true,
                 'fetchOrder': false,
                 'fetchOrderBook': true,
                 'fetchOrders': false,
@@ -140,6 +140,7 @@ export default class hibachi extends Exchange {
                     'get': {
                         'trade/account/info': 1,
                         'trade/account/trades': 1,
+                        'trade/orders': 1,
                     },
                     'put': {
                         'trade/order': 1,
@@ -1018,6 +1019,71 @@ export default class hibachi extends Exchange {
         //
         const trades = this.safeList (response, 'trades');
         return this.parseTrades (trades, market, since, limit, params);
+    }
+
+    parseOrder (order: Dict, market: Market = undefined): Order {
+        
+    }
+
+    /**
+     * @method
+     * @name hibachi#fetchOpenOrders
+     * @description fetches all current open orders
+     * @see https://api-doc.hibachi.xyz/#3243f8a0-086c-44c5-ab8a-71bbb7bab403
+     * @param {string} symbol unified market symbol to filter by
+     * @param {int} [since] milisecond timestamp of the earliest order
+     * @param {int} [limit] the maximum number of open orders to return
+     * @param {object} [params] extra parameters
+     * @returns {Order[]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
+     */
+    async fetchOpenOrders (symbol: string = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
+        await this.loadMarkets ();
+        let market = undefined;
+        if (symbol !== undefined) {
+            market = this.market (symbol);
+        }
+        const request = {
+            'accountId': this.accountId,
+        };
+        const response = await this.privateGetTradeOrders (request);
+        // [
+        //     {
+        //         "accountId": 12452,
+        //         "availableQuantity": "0.0000230769",
+        //         "contractId": 2,
+        //         "creationTime": 1752684501,
+        //         "orderId": "589205486123876352",
+        //         "orderType": "LIMIT",
+        //         "price": "130000.00000",
+        //         "side": "ASK",
+        //         "status": "PLACED",
+        //         "symbol": "BTC/USDT-P",
+        //         "totalQuantity": "0.0000230769"
+        //     },
+        //     {
+        //         "accountId": 12452,
+        //         "availableQuantity": "1.234000000",
+        //         "contractId": 1,
+        //         "creationTime": 1752240682,
+        //         "orderId": "589089141754429441",
+        //         "orderType": "LIMIT",
+        //         "price": "1.234000",
+        //         "side": "BID",
+        //         "status": "PLACED",
+        //         "symbol": "ETH/USDT-P",
+        //         "totalQuantity": "1.234000000"
+        //     }
+        // ]
+        const ordersResult = [];
+        for (let i = 0; i < response.length; i++) {
+            const openOrder = this.safeDict (response, i);
+            if (market !== undefined && market !== this.safeString (openOrder, 'symbol')) {
+                continue;
+            }
+            ordersResult.push ( Order {
+
+            })
+        }
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {


### PR DESCRIPTION
This PR implements the endpoint to fetch the user's open orders.

There are not units tests specifically for this method.

# Testing
Calling the method with no arguments gives all of the users open orders:
```
fetchOpenOrders [
  {
    info: {
      accountId: '12452',
      availableQuantity: '1.234000000',
      contractId: '1',
      creationTime: '1752240682',
      orderId: '589089141754429441',
      orderType: 'LIMIT',
      price: '1.234000',
      side: 'BID',
      status: 'PLACED',
      symbol: 'ETH/USDT-P',
      totalQuantity: '1.234000000'
    },
    id: '589089141754429441',
    clientOrderId: undefined,
    timestamp: 1752240682000,
    datetime: '2025-07-11T13:31:22.000Z',
    lastTradeTimestamp: undefined,
    lastUpdateTimestamp: undefined,
    symbol: 'ETH/USDT:USDT',
    type: undefined,
    timeInForce: undefined,
    postOnly: undefined,
    reduceOnly: undefined,
    side: 'BID',
    price: 1.234,
    triggerPrice: undefined,
    amount: 1.234,
    cost: 0,
    average: undefined,
    filled: 0,
    remaining: 1.234,
    status: undefined,
    fee: undefined,
    trades: [],
    fees: [],
    stopPrice: undefined,
    takeProfitPrice: undefined,
    stopLossPrice: undefined
  },
  {
    info: {
      accountId: '12452',
      availableQuantity: '0.0000230769',
      contractId: '2',
      creationTime: '1752684501',
      orderId: '589205486123876352',
      orderType: 'LIMIT',
      price: '130000.00000',
      side: 'ASK',
      status: 'PLACED',
      symbol: 'BTC/USDT-P',
      totalQuantity: '0.0000230769'
    },
    id: '589205486123876352',
    clientOrderId: undefined,
    timestamp: 1752684501000,
    datetime: '2025-07-16T16:48:21.000Z',
    lastTradeTimestamp: undefined,
    lastUpdateTimestamp: undefined,
    symbol: 'BTC/USDT:USDT',
    type: undefined,
    timeInForce: undefined,
    postOnly: undefined,
    reduceOnly: undefined,
    side: 'SELL',
    price: 130000,
    triggerPrice: undefined,
    amount: 0.0000230769,
    cost: 0,
    average: undefined,
    filled: 0,
    remaining: 0.0000230769,
    status: undefined,
    fee: undefined,
    trades: [],
    fees: [],
    stopPrice: undefined,
    takeProfitPrice: undefined,
    stopLossPrice: undefined
  }
]
```
The user can also limit the number of orders returned:
```
fetchOpenOrdersWithLimit [
  {
    info: {
      accountId: '12452',
      availableQuantity: '0.0000230769',
      contractId: '2',
      creationTime: '1752684501',
      orderId: '589205486123876352',
      orderType: 'LIMIT',
      price: '130000.00000',
      side: 'ASK',
      status: 'PLACED',
      symbol: 'BTC/USDT-P',
      totalQuantity: '0.0000230769'
    },
    id: '589205486123876352',
    clientOrderId: undefined,
    timestamp: 1752684501000,
    datetime: '2025-07-16T16:48:21.000Z',
    lastTradeTimestamp: undefined,
    lastUpdateTimestamp: undefined,
    symbol: 'BTC/USDT:USDT',
    type: undefined,
    timeInForce: undefined,
    postOnly: undefined,
    reduceOnly: undefined,
    side: 'SELL',
    price: 130000,
    triggerPrice: undefined,
    amount: 0.0000230769,
    cost: 0,
    average: undefined,
    filled: 0,
    remaining: 0.0000230769,
    status: undefined,
    fee: undefined,
    trades: [],
    fees: [],
    stopPrice: undefined,
    takeProfitPrice: undefined,
    stopLossPrice: undefined
  }
]
```
And also filter by time and market.