### PR TITLE
Support orderFlags and triggerPrice

### DIFF
--- a/examples/ts/hibachi-example.ts
+++ b/examples/ts/hibachi-example.ts
@@ -52,6 +52,16 @@ async function example () {
     const order5 = await exchange.cancelOrder(order3.id);
     console.log('create, edit and cancel limit order', order3.id, order4.id, order5.id);
 
+    // advanced order parameters
+    const postOnlyOrder = await exchange.createOrder('BTC/USDT:USDT', 'limit', 'buy', 2.0, 2.0, {'timeInForce': 'PO'});
+    await exchange.cancelOrder(postOnlyOrder.id);
+    const iocOrder = await exchange.createOrder('BTC/USDT:USDT', 'limit', 'buy', 2.0, 2.0, {'timeInForce': 'IOC'});
+    await exchange.createOrder('BTC/USDT:USDT', 'market', 'buy', 0.00002);
+    const reduceOnlyOrder = await exchange.createOrder('BTC/USDT:USDT', 'market', 'sell', 0.00002, undefined, {'reduceOnly': true});
+    const triggerOrder = await exchange.createOrder('BTC/USDT:USDT', 'limit', 'sell', 2.0, 2.0, {'triggerPrice': '2.0'});
+    await exchange.cancelOrder(triggerOrder.id);
+    console.log('postOnly, IOC, reduceOnly, trigger order', postOnlyOrder.id, iocOrder.id, reduceOnlyOrder.id, triggerOrder.id);
+
     const order1_info = await exchange.fetchOrder (order1.id, 'BTC/USDT:USDT');
     console.log ('fetchOrder', order1_info);
     

--- a/ts/src/hibachi.ts
+++ b/ts/src/hibachi.ts
@@ -183,16 +183,16 @@ export default class hibachi extends Exchange {
                     'sandbox': false,
                     'createOrder': {
                         'marginMode': false,
-                        'triggerPrice': false,
+                        'triggerPrice': true,
                         'triggerPriceType': undefined,
                         'triggerDirection': undefined,
                         'stopLossPrice': false,
                         'takeProfitPrice': false,
                         'attachedStopLossTakeProfit': undefined,
                         'timeInForce': {
-                            'IOC': false,
+                            'IOC': true,
                             'FOK': false,
-                            'PO': false,
+                            'PO': true,
                             'GTD': false,
                         },
                         'hedged': false,
@@ -878,6 +878,21 @@ export default class hibachi extends Exchange {
             'signature': signature,
             'maxFeesPercent': feeRate.toString (),
         };
+        const postOnly = this.isPostOnly (type.toUpperCase () === 'MARKET', undefined, params);
+        const reduceOnly = this.safeBool2 (params, 'reduceOnly', 'reduce_only');
+        const timeInForce = this.safeStringLower (params, 'timeInForce');
+        const triggerPrice = this.safeString2 (params, 'triggerPrice', 'stopPrice');
+        if (postOnly) {
+            request['orderFlags'] = 'POST_ONLY';
+        } else if (timeInForce === 'ioc') {
+            request['orderFlags'] = 'IOC';
+        } else if (reduceOnly) {
+            request['orderFlags'] = 'REDUCE_ONLY';
+        }
+        if (triggerPrice !== undefined) {
+            request['triggerPrice'] = triggerPrice;
+        }
+        params = this.omit (params, [ 'reduceOnly', 'reduce_only', 'postOnly', 'timeInForce', 'stopPrice', 'triggerPrice' ]);
         const response = await this.privatePostTradeOrder (this.extend (request, params));
         //
         // {


### PR DESCRIPTION
Add support for those advanced orders:
- Trigger order
- Post-only
- Reduce-only
- IOC

**Test**
Build and unit tests can pass.
Added examples, here are the request body for each order:
Post-only:
```
 {"accountId":221,"symbol":"BTC/USDT-P","nonce":1752809351470,"side":"BID","orderType":"LIMIT","quantity":"2","price":"2","signature":"ef863c360e09a004a0b32c04174b3482aa14c337a694ba900c9332bac4d00d361a519d8ecc3f5a9db592c4b0768f2462300be30247dddccd35e34852b8e553af01","maxFeesPercent":"0.0002","orderFlags":"POST_ONLY"}
```
IOC
```
 {"accountId":221,"symbol":"BTC/USDT-P","nonce":1752809417278,"side":"BID","orderType":"LIMIT","quantity":"2","price":"2","signature":"7291a7548353d2da62c2c8ffd4e57d1d5f211a3b3c33d98cf49227a282b5f62e52f478836e267899cb7995172c020b3ef85621f596daf937428827202c8c3bed00","maxFeesPercent":"0.0002","orderFlags":"IOC"}
```
Reduce-only:
```
 {"accountId":221,"symbol":"BTC/USDT-P","nonce":1752809788609,"side":"ASK","orderType":"MARKET","quantity":"0.00002","price":"","signature":"557a560d0a0c422293fb4e70642d0826c23d287634f6f0012906b60f824645ea6543dfd27663337fd441a01b8f86af7cac240c1ff935ad51f85d33a35cb1dbfb01","maxFeesPercent":"0.0002","orderFlags":"REDUCE_ONLY"}
```
Trigger order:
```
 {"accountId":221,"symbol":"BTC/USDT-P","nonce":1752810023505,"side":"ASK","orderType":"LIMIT","quantity":"2","price":"2","signature":"4df22fac3c133a41946994d1f9985325e5b5fb72fd1827e28eb3809924ba8af93cbc26171b06aa02a5ea30ddf584f26d387e4024f9d719c0dbf46d318be69bc201","maxFeesPercent":"0.0002","triggerPrice":"2.0"}
```