### PR TITLE
Set fee amount

### DIFF
--- a/ts/src/hibachi.ts
+++ b/ts/src/hibachi.ts
@@ -173,8 +173,8 @@ export default class hibachi extends Exchange {
                 'trading': {
                     'tierBased': false,
                     'percentage': true,
-                    'maker': this.parseNumber ('0.0000'),
-                    'taker': this.parseNumber ('0.0002'),
+                    'maker': this.parseNumber ('0.00015'),
+                    'taker': this.parseNumber ('0.00045'),
                 },
             },
             'options': {


### PR DESCRIPTION
Context: [ENG-5244: Add a single source of truth for fee information](https://linear.app/hibachi-xyz/issue/ENG-5244/add-a-single-source-of-truth-for-fee-information)

By the time this gets merged, we would have reverted to the original fees of 4.5 and 1.5 bps.